### PR TITLE
Ensure URL ends with a trailing slash

### DIFF
--- a/ddwrt-autoupdate
+++ b/ddwrt-autoupdate
@@ -19,6 +19,7 @@ error() {
 
 list_files() {
     local url="$1"
+    [[ "$url" == */ ]] || url="$url/"
     curl -Lfs "$url" | sed -n 's/^<a href="\([^/"]*\)\/">\1\/<\/a>.*$/\1/p'
 }
 


### PR DESCRIPTION
Fixed issue where requests failed due to missing trailing slashes. Without the trailing slash, requests were redirected to https://download1.dd-wrt.com:8080/, resulting in a timeout and no response from the server.